### PR TITLE
[ID-32] 인증인가 파라미터 email -> id

### DIFF
--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/auth/dto/LoginResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/auth/dto/LoginResp.java
@@ -1,3 +1,3 @@
 package com.ureca.idle.idleapi.idleoriginapi.business.auth.dto;
 
-public record LoginResp (String email, String role) {}
+public record LoginResp (Long id, String role) {}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingService.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingService.java
@@ -22,8 +22,8 @@ public class KidManagingService implements KidManagingUseCase {
 
     @Override
     @Transactional
-    public AddKidResp addMyKid(String email, AddKidReq req) {
-        User loginUser = userManager.getCurrentLoginUser(email);
+    public AddKidResp addMyKid(Long userId, AddKidReq req) {
+        User loginUser = userManager.getCurrentLoginUser(userId);
         kidManager.checkDuplicatedKidName(loginUser, req.name());
         Kid newKid = kidManager.registerKid(loginUser, req.name(), req.gender(), req.birthDate());
         return kidDtoMapper.toAddKidResp(newKid);
@@ -31,8 +31,8 @@ public class KidManagingService implements KidManagingUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public GetKidsProfilesResp getMyKidsProfiles(String email) {
-        User loginUser = userManager.getCurrentLoginUser(email);
+    public GetKidsProfilesResp getMyKidsProfiles(Long userId) {
+        User loginUser = userManager.getCurrentLoginUser(userId);
         List<Kid> loginUsersKids = kidManager.getKidsByUser(loginUser);
         return kidDtoMapper.toGetMyKidsProfilesResp(loginUsersKids);
     }
@@ -40,8 +40,8 @@ public class KidManagingService implements KidManagingUseCase {
     // TODO 현재 사용자와 join 해서 찾을 필요가 있을까? 일단 지금은 아이의 ID 로만 찾는다
     @Override
     @Transactional(readOnly = true)
-    public GetKidsDetailResp getMyKidsDetail(String email, Long kidId) {
-        userManager.checkCurrentLoginUser(email);
+    public GetKidsDetailResp getMyKidsDetail(Long userId, Long kidId) {
+        userManager.checkCurrentLoginUser(userId);
         Kid kid = kidManager.getKidWithPersonality(kidId);
         return kidDtoMapper.toGetKidsDetailResp(kid);
     }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingUseCase.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingUseCase.java
@@ -3,7 +3,7 @@ package com.ureca.idle.idleapi.idleoriginapi.business.kid;
 import com.ureca.idle.idleapi.idleoriginapi.business.kid.dto.*;
 
 public interface KidManagingUseCase {
-    AddKidResp addMyKid(String email, AddKidReq req);
-    GetKidsProfilesResp getMyKidsProfiles(String email);
-    GetKidsDetailResp getMyKidsDetail(String email, Long kidId);
+    AddKidResp addMyKid(Long userId, AddKidReq req);
+    GetKidsProfilesResp getMyKidsProfiles(Long userId);
+    GetKidsDetailResp getMyKidsDetail(Long userId, Long kidId);
 }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/mapper/AuthDtoMapper.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/mapper/AuthDtoMapper.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class AuthDtoMapper {
 
     public LoginResp toLoginResp(User loginUser) {
-        return new LoginResp(loginUser.getEmail(), loginUser.getRole().getValue());
+        return new LoginResp(loginUser.getId(), loginUser.getRole().getValue());
     }
 
     public SignupResp toSignupResp(User registeredUser) {

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/user/UserManager.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/user/UserManager.java
@@ -13,7 +13,7 @@ public class UserManager {
 
     private final UserRepository repository;
 
-    public User getUserById(Long id) {
+    public User getUser(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException("해당 ID 를 가진 유저를 찾을 수 없습니다."));
     }
@@ -29,13 +29,13 @@ public class UserManager {
     }
 
     // TODO AuthManager 생성 고려
-    public User getCurrentLoginUser(String email) {
-        return repository.findByEmail(email)
+    public User getCurrentLoginUser(Long id) {
+        return repository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException("현재 로그인한 유저를 찾을 수 없습니다, 다시 로그인해주세요."));
     }
 
-    public void checkCurrentLoginUser(String email) {
-        if(!repository.existsByEmail(email)) {
+    public void checkCurrentLoginUser(Long id) {
+        if(!repository.existsById(id)) {
             throw new UserNotFoundException("현재 로그인한 유저를 찾을 수 없습니다, 다시 로그인해주세요.");
         }
     }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/auth/AuthController.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/auth/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<JwtDto> login(@RequestBody LoginReq req) {
         LoginResp resp = authUseCase.login(req);
-        String jwt = jwtProvider.create(resp.email(), resp.role());
+        String jwt = jwtProvider.create(resp.id(), resp.role());
         return ResponseEntity.ok(new JwtDto(jwt));
     }
 

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
@@ -21,19 +21,19 @@ public class KidManagingController {
 
     @PostMapping("")
     public ResponseEntity<AddKidResp> addMyKid(@LoginUser IdAndAuthority loginUser, @RequestBody AddKidReq req) {
-        AddKidResp resp = kidManagingUseCase.addMyKid(loginUser.email(), req);
+        AddKidResp resp = kidManagingUseCase.addMyKid(loginUser.id(), req);
         return ResponseEntity.ok(resp);
     }
 
     @GetMapping("")
     public ResponseEntity<GetKidsProfilesResp> getMyKidsProfiles(@LoginUser IdAndAuthority loginUser) {
-        GetKidsProfilesResp resp = kidManagingUseCase.getMyKidsProfiles(loginUser.email());
+        GetKidsProfilesResp resp = kidManagingUseCase.getMyKidsProfiles(loginUser.id());
         return ResponseEntity.ok(resp);
     }
 
     @GetMapping("/{kidId}/detail")
     public ResponseEntity<GetKidsDetailResp> getMyKidsDetail(@LoginUser IdAndAuthority loginUser, @PathVariable Long kidId) {
-        GetKidsDetailResp resp = kidManagingUseCase.getMyKidsDetail(loginUser.email(), kidId);
+        GetKidsDetailResp resp = kidManagingUseCase.getMyKidsDetail(loginUser.id(), kidId);
         return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/com/ureca/idle/idleapi/web/auth/IdAndAuthority.java
+++ b/src/main/java/com/ureca/idle/idleapi/web/auth/IdAndAuthority.java
@@ -1,3 +1,3 @@
 package com.ureca.idle.idleapi.web.auth;
 
-public record IdAndAuthority(String email, String role) {}
+public record IdAndAuthority(Long id, String role) {}

--- a/src/main/java/com/ureca/idle/idleapi/web/jwt/JwtProvider.java
+++ b/src/main/java/com/ureca/idle/idleapi/web/jwt/JwtProvider.java
@@ -26,9 +26,9 @@ public class JwtProvider {
         key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes());
     }
 
-    public String create(String email, String role) {
+    public String create(Long userId, String role) {
         Claims claims = Jwts.claims();
-        claims.put("email", email);
+        claims.put("id", userId);
         claims.put("role", role);
         return createToken(claims);
     }
@@ -58,7 +58,7 @@ public class JwtProvider {
                     .setSigningKey(jwtProperties.getSecret().getBytes())
                     .parseClaimsJws(token)
                     .getBody();
-            return new IdAndAuthority(claims.get("email", String.class), claims.get("role", String.class));
+            return new IdAndAuthority(claims.get("id", Long.class), claims.get("role", String.class));
         } catch (MalformedJwtException e) {
             throw new JwtException("토큰의 길이 및 형식이 올바르지 않습니다.");
         } catch (ExpiredJwtException e) {


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- [resolves]: [ID-32 인증인가 파라미터 email -> id](https://trello.com/c/V2b1emMm/32-id-32-%EC%9D%B8%EC%A6%9D%EC%9D%B8%EA%B0%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0-email-id)

> ## 💻 작업 내용
- 인증인가 파라미터 email -> id
- email 로 찾는 로직이 많아질 시 email 인덱스 생성이 불가피, id 는 이미 클러스터 인덱스로 기본 생성
- 도메인을 구별할 조건은 email 같은 도메인의 특정 필드보다는 id 로 하는 것이 조금 더 범용적, 보편적
- 그렇기 때문에 인증인가 파라미터를 email -> id 로 변환
---
> ## 🙇 특이 사항
- 
---
> ## 👻 리뷰 요구사항 (선택)
- 
---