### PR TITLE
[ID-34] 인증인가 책임 business layer 에서 빼기

### DIFF
--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingService.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingService.java
@@ -40,8 +40,7 @@ public class KidManagingService implements KidManagingUseCase {
     // TODO 현재 사용자와 join 해서 찾을 필요가 있을까? 일단 지금은 아이의 ID 로만 찾는다
     @Override
     @Transactional(readOnly = true)
-    public GetKidsDetailResp getMyKidsDetail(Long userId, Long kidId) {
-        userManager.checkCurrentLoginUser(userId);
+    public GetKidsDetailResp getKidsDetail(Long kidId) {
         Kid kid = kidManager.getKidWithPersonality(kidId);
         return kidDtoMapper.toGetKidsDetailResp(kid);
     }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingUseCase.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/kid/KidManagingUseCase.java
@@ -5,5 +5,5 @@ import com.ureca.idle.idleapi.idleoriginapi.business.kid.dto.*;
 public interface KidManagingUseCase {
     AddKidResp addMyKid(Long userId, AddKidReq req);
     GetKidsProfilesResp getMyKidsProfiles(Long userId);
-    GetKidsDetailResp getMyKidsDetail(Long userId, Long kidId);
+    GetKidsDetailResp getKidsDetail(Long kidId);
 }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/user/UserManager.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/user/UserManager.java
@@ -34,12 +34,6 @@ public class UserManager {
                 .orElseThrow(() -> new UserNotFoundException("현재 로그인한 유저를 찾을 수 없습니다, 다시 로그인해주세요."));
     }
 
-    public void checkCurrentLoginUser(Long id) {
-        if(!repository.existsById(id)) {
-            throw new UserNotFoundException("현재 로그인한 유저를 찾을 수 없습니다, 다시 로그인해주세요.");
-        }
-    }
-
     public User registerUser(String email, String password, String name, String phoneNum) {
         User newUser = User.builder()
                 .email(email)

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
@@ -33,7 +33,7 @@ public class KidManagingController {
 
     @GetMapping("/{kidId}/detail")
     public ResponseEntity<GetKidsDetailResp> getMyKidsDetail(@LoginUser IdAndAuthority loginUser, @PathVariable Long kidId) {
-        GetKidsDetailResp resp = kidManagingUseCase.getMyKidsDetail(loginUser.id(), kidId);
+        GetKidsDetailResp resp = kidManagingUseCase.getKidsDetail(kidId);
         return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/kid/KidManagingController.java
@@ -32,7 +32,7 @@ public class KidManagingController {
     }
 
     @GetMapping("/{kidId}/detail")
-    public ResponseEntity<GetKidsDetailResp> getMyKidsDetail(@LoginUser IdAndAuthority loginUser, @PathVariable Long kidId) {
+    public ResponseEntity<GetKidsDetailResp> getMyKidsDetail(/*TODO @LoginUser 이외에 인증인가 검증 필터를 만들 것*/@LoginUser IdAndAuthority loginUser, @PathVariable Long kidId) {
         GetKidsDetailResp resp = kidManagingUseCase.getKidsDetail(kidId);
         return ResponseEntity.ok(resp);
     }


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- [resolves]: [ID-34 인증인가 책임 business layer 에서 빼기](https://trello.com/c/qh95Rs0B/34-id-34-%EC%9D%B8%EC%A6%9D%EC%9D%B8%EA%B0%80-%EC%B1%85%EC%9E%84-business-layer-%EC%97%90%EC%84%9C-%EB%B9%BC%EA%B8%B0)

> ## 💻 작업 내용
- 비즈니스 로직만 나타내기 위해 business layer 에 웹 종속을 뺄 필요가 있다
- 인증인가 책임은 웹(presentaion layer) 가 가지고 있는 것이 조금 더 적절하다 
- 따라서 인증인가 책임을 business layer 에서 빼기 위해 checkCurrentLoginUser 기능은 웹 쪽으로 뺀다
- 단, 이를 위해 현재 @LoginUser 어노테이션과 아규먼트 리솔브로 jwt 검증을 하는 방법에서 필터 검증으로의 발전이 필요하다
---
> ## 🙇 특이 사항
- 
---
> ## 👻 리뷰 요구사항 (선택)
- 
---