### PR TITLE
[ID-42] 성향 테스트 질문 엔티티 추가 및 성향 질문 조회 기능 구현

### DIFF
--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
@@ -6,7 +6,7 @@ import com.ureca.idle.idleapi.idleoriginapi.implementation.mapper.PersonalityDto
 import com.ureca.idle.idleapi.idleoriginapi.implementation.personality.PersonalityManager;
 import com.ureca.idle.idleapi.idleoriginapi.implementation.user.UserManager;
 import com.ureca.idle.idlejpa.question.PersonalityQuestion;
-import com.ureca.idle.idlejpa.user.User;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
@@ -1,36 +1,51 @@
 package com.ureca.idle.idleapi.idleoriginapi.business.personality;
 
 
-import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.AddKidPersonalityResp;
-import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetKidsPersonalityHistoryResp;
-import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetTestQuestionsResp;
-import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.RemoveKidPersonalityResp;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.*;
+import com.ureca.idle.idleapi.idleoriginapi.implementation.mapper.PersonalityDtoMapper;
+import com.ureca.idle.idleapi.idleoriginapi.implementation.personality.PersonalityManager;
+import com.ureca.idle.idleapi.idleoriginapi.implementation.user.UserManager;
+import com.ureca.idle.idlejpa.question.PersonalityQuestion;
+import com.ureca.idle.idlejpa.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PersonalityManagingService implements PersonalityManagingUseCase{
 
-
+    private final UserManager userManager;
+    private final PersonalityManager personalityManager;
+    private final PersonalityDtoMapper personalityDtoMapper;
 
     @Override
-    public AddKidPersonalityResp addMyKidPersonality() {
+    public AddKidPersonalityResp addMyKidPersonality(Long kidId, AddKidPersonalityReq req) {
+        // 사용자 getCurrentUserlogin 사용해서 현재 로그인한 사용자 가져오고
+        // 테스트 결과를 kidId에 넣고
+        // 흠.. 이걸 Kid 안에 넣어주는 거면, Kid dto Mapper에 해당 MBTI 결과를 넣는 메소드 만들어줘야할듯
+
         return null;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public GetTestQuestionsResp getPersonalityTestQuestions() {
+        List<PersonalityQuestion> questionList = personalityManager.getPersonalityQuestions();
+        return personalityDtoMapper.toGetPersonalityQuestions(questionList);
+    }
+
+    @Override
+    public RemoveKidPersonalityResp removePersonality(Long userId, Long kidId) {
+
         return null;
     }
 
     @Override
-    public RemoveKidPersonalityResp removePersonality() {
-        return null;
-    }
+    public GetKidsPersonalityHistoryResp getKidsPersonalityHistory(Long kidId) {
 
-    @Override
-    public GetKidsPersonalityHistoryResp getKidsPersonalityHistory() {
         return null;
     }
 }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingService.java
@@ -1,0 +1,36 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality;
+
+
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.AddKidPersonalityResp;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetKidsPersonalityHistoryResp;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetTestQuestionsResp;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.RemoveKidPersonalityResp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalityManagingService implements PersonalityManagingUseCase{
+
+
+
+    @Override
+    public AddKidPersonalityResp addMyKidPersonality() {
+        return null;
+    }
+
+    @Override
+    public GetTestQuestionsResp getPersonalityTestQuestions() {
+        return null;
+    }
+
+    @Override
+    public RemoveKidPersonalityResp removePersonality() {
+        return null;
+    }
+
+    @Override
+    public GetKidsPersonalityHistoryResp getKidsPersonalityHistory() {
+        return null;
+    }
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingUseCase.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingUseCase.java
@@ -5,17 +5,16 @@ import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.*;
 public interface PersonalityManagingUseCase {
     // 1. 성향 검사 진행 결과 발송
     // 프론트에서 테스트 진행 -> 결과를 서버로 전송 -> 아이 성향에 반영
-    AddKidPersonalityResp addMyKidPersonality();
+    AddKidPersonalityResp addMyKidPersonality(Long kidId, AddKidPersonalityReq req);
 
     // 2. 성향 테스트 질문지들 Get 요청
     GetTestQuestionsResp getPersonalityTestQuestions();
 
-
     // 3. 성향 삭제 요청
-    RemoveKidPersonalityResp removePersonality();
+    RemoveKidPersonalityResp removePersonality(Long userId, Long kidId);
 
     // 4. 성향 히스토리 조회
-    GetKidsPersonalityHistoryResp getKidsPersonalityHistory();
+    GetKidsPersonalityHistoryResp getKidsPersonalityHistory(Long kidId);
 
 
 

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingUseCase.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/PersonalityManagingUseCase.java
@@ -1,0 +1,24 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality;
+
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.*;
+
+public interface PersonalityManagingUseCase {
+    // 1. 성향 검사 진행 결과 발송
+    // 프론트에서 테스트 진행 -> 결과를 서버로 전송 -> 아이 성향에 반영
+    AddKidPersonalityResp addMyKidPersonality();
+
+    // 2. 성향 테스트 질문지들 Get 요청
+    GetTestQuestionsResp getPersonalityTestQuestions();
+
+
+    // 3. 성향 삭제 요청
+    RemoveKidPersonalityResp removePersonality();
+
+    // 4. 성향 히스토리 조회
+    GetKidsPersonalityHistoryResp getKidsPersonalityHistory();
+
+
+
+    
+
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityReq.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityReq.java
@@ -1,0 +1,4 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+public record AddKidPersonalityReq(int ei, int sn, int tf, int jp, String mbti) {
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityResp.java
@@ -1,0 +1,4 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+public record AddKidPersonalityResp() {
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/AddKidPersonalityResp.java
@@ -1,4 +1,4 @@
 package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
 
-public record AddKidPersonalityResp() {
+public record AddKidPersonalityResp(Long kidId, AddKidPersonalityReq req) {
 }

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetKidsPersonalityHistoryResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetKidsPersonalityHistoryResp.java
@@ -1,0 +1,4 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+public record GetKidsPersonalityHistoryResp() {
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetQuestionsDetailResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetQuestionsDetailResp.java
@@ -1,0 +1,7 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+import com.ureca.idle.idlejpa.question.MBTIType;
+
+public record GetQuestionsDetailResp(Long id, String question, String answer1, String answer2, int value, MBTIType type) {
+
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetTestQuestionsResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetTestQuestionsResp.java
@@ -1,4 +1,5 @@
 package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
 
-public record GetTestQuestionsResp() {
-}
+import java.util.List;
+
+public record GetTestQuestionsResp(List<GetQuestionsDetailResp> questions) {}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetTestQuestionsResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/GetTestQuestionsResp.java
@@ -1,0 +1,4 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+public record GetTestQuestionsResp() {
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/RemoveKidPersonalityResp.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/business/personality/dto/RemoveKidPersonalityResp.java
@@ -1,0 +1,4 @@
+package com.ureca.idle.idleapi.idleoriginapi.business.personality.dto;
+
+public record RemoveKidPersonalityResp() {
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/mapper/PersonalityDtoMapper.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/mapper/PersonalityDtoMapper.java
@@ -1,0 +1,24 @@
+package com.ureca.idle.idleapi.idleoriginapi.implementation.mapper;
+
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetQuestionsDetailResp;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetTestQuestionsResp;
+import com.ureca.idle.idlejpa.question.PersonalityQuestion;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PersonalityDtoMapper {
+    public GetTestQuestionsResp toGetPersonalityQuestions(List<PersonalityQuestion> questions) {
+        return new GetTestQuestionsResp(
+                questions.stream()
+                        .map(this::toGetPersonalityQuestions)
+                        .toList()
+
+        );
+    }
+
+    public GetQuestionsDetailResp toGetPersonalityQuestions(PersonalityQuestion question) {
+        return new GetQuestionsDetailResp(question.getId(), question.getQuestion(), question.getAnswer1(), question.getAnswer2(), question.getValue(), question.getMbtiType());
+    }
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/personality/PersonalityManager.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/implementation/personality/PersonalityManager.java
@@ -1,0 +1,23 @@
+package com.ureca.idle.idleapi.idleoriginapi.implementation.personality;
+
+import com.ureca.idle.idleapi.idleoriginapi.persistence.personality.PersonalityRepository;
+import com.ureca.idle.idlejpa.question.PersonalityQuestion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+
+@Component
+@RequiredArgsConstructor
+public class PersonalityManager {
+    private final PersonalityRepository repository;
+
+
+    public List<PersonalityQuestion> getPersonalityQuestions(){
+        return repository.findAll();
+    }
+
+
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/persistence/personality/PersonalityRepository.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/persistence/personality/PersonalityRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Component
 public interface PersonalityRepository extends JpaRepository<PersonalityQuestion, Long> {
-    List<PersonalityQuestion> findAll(Long questionId);
+    List<PersonalityQuestion> findAll();
 
 
 

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/persistence/personality/PersonalityRepository.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/persistence/personality/PersonalityRepository.java
@@ -1,0 +1,17 @@
+package com.ureca.idle.idleapi.idleoriginapi.persistence.personality;
+
+import com.ureca.idle.idlejpa.question.PersonalityQuestion;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.List;
+
+@Component
+public interface PersonalityRepository extends JpaRepository<PersonalityQuestion, Long> {
+    List<PersonalityQuestion> findAll(Long questionId);
+
+
+
+}

--- a/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/controller/personality/personalityController.java
+++ b/src/main/java/com/ureca/idle/idleapi/idleoriginapi/presentaion/controller/personality/personalityController.java
@@ -1,0 +1,25 @@
+package com.ureca.idle.idleapi.idleoriginapi.presentaion.controller.personality;
+
+
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.PersonalityManagingUseCase;
+import com.ureca.idle.idleapi.idleoriginapi.business.personality.dto.GetTestQuestionsResp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/personalities")
+@RequiredArgsConstructor
+public class personalityController {
+    private final PersonalityManagingUseCase personalityManagingUseCase;
+
+    @GetMapping("")
+    public ResponseEntity<GetTestQuestionsResp> getTestQuestions() {
+        GetTestQuestionsResp resp = personalityManagingUseCase.getPersonalityTestQuestions();
+        return ResponseEntity.ok(resp);
+    }
+
+
+}

--- a/src/main/java/com/ureca/idle/idlejpa/question/MBTIType.java
+++ b/src/main/java/com/ureca/idle/idlejpa/question/MBTIType.java
@@ -1,0 +1,20 @@
+package com.ureca.idle.idlejpa.question;
+
+import lombok.Getter;
+
+@Getter
+public enum MBTIType {
+    EI("ei"),
+    SN("sn"),
+    TF("tf"),
+    JP("jp");
+
+    private final String value;
+
+    MBTIType(String value) {
+        this.value = value;
+    }
+
+
+
+}

--- a/src/main/java/com/ureca/idle/idlejpa/question/PersonalityQuestion.java
+++ b/src/main/java/com/ureca/idle/idlejpa/question/PersonalityQuestion.java
@@ -1,0 +1,30 @@
+package com.ureca.idle.idlejpa.question;
+
+import com.ureca.idle.idlejpa.config.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class PersonalityQuestion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column(nullable = false)
+    private String answer1;
+
+    @Column(nullable = false)
+    private String answer2;
+
+    @Column(nullable = false)
+    private int value;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MBTIType mbtiType;
+}


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- [resolves]: [ID-25 성향 질문 테이블 추가 및 엔티티 추가](https://trello.com/c/TpcpyPnq/42-id-42-%EC%84%B1%ED%96%A5-%EC%A7%88%EB%AC%B8-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%B6%94%EA%B0%80-%EB%B0%8F-%EC%97%94%ED%8B%B0%ED%8B%B0-%EC%B6%94%EA%B0%80)

> ## 💻 작업 내용
- 성향 질문에 대한 테이블을 ERD에 추가했고 엔티티 생성했습니다. 
- 테스트 질문들을 조회하는 기능도 구현했습니다.
---
> ## 👻 리뷰 요구사항 (선택)
- 질문 조회를 하면서 MBTIType이라는 Enum을 JPA에 만들어서 GetQuestionsDetailResp Dto에 사용했는데 이게 혹시 우리 아키텍처 규칙에 어긋나는지 확인부탁드립니다!
---
