### PR TITLE
[ID-65] 자녀 성향 삭제 배치 구현

### DIFF
--- a/src/main/java/com/ureca/idle/batch/ScheduledTasks.java
+++ b/src/main/java/com/ureca/idle/batch/ScheduledTasks.java
@@ -19,6 +19,10 @@ public class ScheduledTasks {
     @Autowired
     private Job saveKidsPersonalityJob;
 
+    @Autowired
+    private Job deleteBatchJob;
+
+
     @Scheduled(cron = "*/20 * * * * ?")
     public void runBatchJob() {
         try {
@@ -29,6 +33,18 @@ public class ScheduledTasks {
             jobLauncher.run(saveKidsPersonalityJob, jobParameters);
             System.out.println("Batch job started successfully.");
         } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Scheduled(cron = "*/10 * * * * *")
+    public void runDeleteJob() {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+            jobLauncher.run(deleteBatchJob, jobParameters);
+        } catch (Exception e){
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemReader.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemReader.java
@@ -1,8 +1,6 @@
 package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
 
 
-import com.ureca.idle.batch.domain.KidsPersonalityDeleteHistoryDtoRowMapper;
-import com.ureca.idle.batch.dto.KidsPersonalityDeleteHistoryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.PagingQueryProvider;

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemReader.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemReader.java
@@ -1,0 +1,49 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+
+import com.ureca.idle.batch.domain.KidsPersonalityDeleteHistoryDtoRowMapper;
+import com.ureca.idle.batch.dto.KidsPersonalityDeleteHistoryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeleteKidsItemReader {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Bean
+    public JdbcPagingItemReader<KidsPersonalityDeleteHistoryDto> deleteItemReader() {
+        return new JdbcPagingItemReaderBuilder<KidsPersonalityDeleteHistoryDto>()
+                .name("deleteItemReader")
+                .dataSource(dataSource)
+                .rowMapper(new KidsPersonalityDeleteHistoryDtoRowMapper())
+                .queryProvider(queryProvider())
+                .build();
+    }
+
+    @Bean
+    public PagingQueryProvider queryProvider() {
+        SqlPagingQueryProviderFactoryBean pagingQueryProvider = new SqlPagingQueryProviderFactoryBean();
+        pagingQueryProvider.setSelectClause("SELECT id, created_at");
+        pagingQueryProvider.setFromClause("FROM kids_personality_delete_history");
+        pagingQueryProvider.setWhereClause("WHERE DATE_SUB(NOW(), Interval 30 day) > created_at");  // 현재 일자가 created_at가 30일을 초과한 경우
+        pagingQueryProvider.setDataSource(dataSource);
+        pagingQueryProvider.setSortKey("id");
+
+        try {
+            return pagingQueryProvider.getObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemWriter.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsItemWriter.java
@@ -1,0 +1,29 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeleteKidsItemWriter {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Bean
+    public JdbcBatchItemWriter<Long> deleteItemWriter() {
+        return new JdbcBatchItemWriterBuilder<Long>()
+                .dataSource(dataSource)
+                .sql("DELETE FROM kids_personality_delete_history where id = :id")
+                .itemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsJobConfiguration.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsJobConfiguration.java
@@ -1,0 +1,24 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeleteKidsJobConfiguration {
+
+    @Bean
+    public Job deleteBatchJob(Step deleteBatchStep, JobRepository jobRepository) throws Exception {
+        System.out.println("Delete Job Start");
+        return new JobBuilder("deleteKidsPersonalityBatchJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(deleteBatchStep)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsStepConfiguration.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsStepConfiguration.java
@@ -1,6 +1,5 @@
 package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
 
-import com.ureca.idle.batch.dto.KidsPersonalityDeleteHistoryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.repository.JobRepository;

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsStepConfiguration.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/DeleteKidsStepConfiguration.java
@@ -1,0 +1,28 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+import com.ureca.idle.batch.dto.KidsPersonalityDeleteHistoryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeleteKidsStepConfiguration {
+
+    private final JdbcPagingItemReader<KidsPersonalityDeleteHistoryDto> deleteItemReader;
+    private final JdbcBatchItemWriter<Long> deleteItemWriter;
+    @Bean
+    public Step deleteBatchStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) throws Exception {
+        return new StepBuilder("deleteBatchStep", jobRepository)
+                .<KidsPersonalityDeleteHistoryDto, Long>chunk(10, transactionManager)
+                .reader(deleteItemReader)
+                .writer(deleteItemWriter)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/KidsPersonalityDeleteHistoryDto.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/KidsPersonalityDeleteHistoryDto.java
@@ -1,0 +1,17 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+//@RequiredArgsConstructor
+public class KidsPersonalityDeleteHistoryDto {
+    private Long Id;
+    private LocalDateTime createdAt;
+
+    public KidsPersonalityDeleteHistoryDto(Long id, LocalDateTime createdAt) {
+        this.Id = id;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/KidsPersonalityDeleteHistoryDtoRowMapper.java
+++ b/src/main/java/com/ureca/idle/batch/kidsPersonalityDeleteHistory/KidsPersonalityDeleteHistoryDtoRowMapper.java
@@ -1,0 +1,15 @@
+package com.ureca.idle.batch.kidsPersonalityDeleteHistory;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class KidsPersonalityDeleteHistoryDtoRowMapper implements RowMapper<KidsPersonalityDeleteHistoryDto> {
+
+    @Override
+    public KidsPersonalityDeleteHistoryDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+        KidsPersonalityDeleteHistoryDto dto = new KidsPersonalityDeleteHistoryDto(rs.getLong("id"), rs.getTimestamp("created_at").toLocalDateTime());
+        return dto;
+    }
+}


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- [resolves]: [ID-65 자녀 성향 삭제 배치 구현](https://trello.com/c/Te9g69n6/65-id-65-%EC%9E%90%EB%85%80-%EC%84%B1%ED%96%A5-%EC%82%AD%EC%A0%9C-%EB%B0%B0%EC%B9%98-%EA%B5%AC%ED%98%84)

> ## 💻 작업 내용
- 자녀 DeleteHistory 30일 지난 삭제 기록은 완전 삭제 배치 기능 구현
---
> ## 🙇 특이 사항
- 스케쥴러를 테스트를 위해 10초 단위로 했으나 차후 매일 새벽 트래픽이 적은 시간대에 실행하는 것으로 수정해야합니다.
- Chunk 사이즈 및 Paging 깨짐 문제에 대한 테스트 예정입니다
---
> ## 👻 리뷰 요구사항 (선택)
- 꼼꼼히 봐주세요!!
---
