### PR TITLE
[ID-83] 배치 로직 수정

### DIFF
--- a/src/main/java/com/ureca/idle/batch/submissionhistory/FcfsEventPropertiesForBatch.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/FcfsEventPropertiesForBatch.java
@@ -1,0 +1,13 @@
+package com.ureca.idle.batch.submissionhistory;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "event.fcfs")
+public class FcfsEventPropertiesForBatch {
+    private String startTime;
+    private String endTime;
+}

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/FcfsEventPropertiesForBatch.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/FcfsEventPropertiesForBatch.java
@@ -4,10 +4,12 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalTime;
+
 @Data
 @Component
 @ConfigurationProperties(prefix = "event.fcfs")
 public class FcfsEventPropertiesForBatch {
-    private String startTime;
-    private String endTime;
+    private LocalTime startTime;
+    private LocalTime endTime;
 }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/SubmissionBatchTimeUtils.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/SubmissionBatchTimeUtils.java
@@ -8,7 +8,7 @@ import java.time.format.DateTimeFormatter;
 
 @Component
 @RequiredArgsConstructor
-public class TimeUtils {
+public class SubmissionBatchTimeUtils {
 
     private final FcfsEventPropertiesForBatch fcfsEventPropertiesForBatch;
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/SubmissionHistoryBatchManager.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/SubmissionHistoryBatchManager.java
@@ -17,7 +17,8 @@ public class SubmissionHistoryBatchManager {
             values.append("(")
                     .append("'").append(currentRoundSubmission.getUserId()).append("', ")
                     .append("'").append(currentRoundSubmission.getName()).append("', ")
-                    .append("'").append(currentRoundSubmission.getPhoneNum()).append("'), ");
+                    .append("'").append(currentRoundSubmission.getPhoneNum()).append("', ")
+                    .append("'").append(currentRoundSubmission.getTimeStamp()).append("'), ");
         } catch (Exception e) {
             throw new SubmissionHistoryBatchException(
                     SubmissionHistoryBatchExceptionType.PREVIOUS_SUBMISSION_HISTORY_NOT_SAVE_EXCEPTION_TYPRE);

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
@@ -1,0 +1,19 @@
+package com.ureca.idle.batch.submissionhistory;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtils {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static String getStartTime() {
+        LocalDateTime startTime = LocalDateTime.now().minusDays(1).withHour(13).withMinute(0).withSecond(0);
+        return startTime.format(FORMATTER);
+    }
+
+    public static String getEndTime() {
+        LocalDateTime endTime = LocalDateTime.now().withHour(12).withMinute(59).withSecond(59);
+        return endTime.format(FORMATTER);
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
@@ -1,19 +1,31 @@
 package com.ureca.idle.batch.submissionhistory;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+@Component
+@RequiredArgsConstructor
 public class TimeUtils {
 
+    private final FcfsEventPropertiesForBatch fcfsEventPropertiesForBatch;
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    public static String getStartTime() {
-        LocalDateTime startTime = LocalDateTime.now().minusDays(1).withHour(13).withMinute(0).withSecond(0);
+    public String getStartTime() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startTime = now.minusDays(1).withHour(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[0]))
+                .withMinute(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[1]))
+                .withSecond(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[2]));
         return startTime.format(FORMATTER);
     }
 
-    public static String getEndTime() {
-        LocalDateTime endTime = LocalDateTime.now().withHour(12).withMinute(59).withSecond(59);
+    public String getEndTime() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime endTime = now.withHour(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[0]))
+                .withMinute(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[1]))
+                .withSecond(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[2]));
         return endTime.format(FORMATTER);
     }
 }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/TimeUtils.java
@@ -15,17 +15,19 @@ public class TimeUtils {
 
     public String getStartTime() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startTime = now.minusDays(1).withHour(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[0]))
-                .withMinute(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[1]))
-                .withSecond(Integer.parseInt(fcfsEventPropertiesForBatch.getStartTime().split(":")[2]));
+        LocalDateTime startTime = now.minusDays(1)
+                .withHour(fcfsEventPropertiesForBatch.getStartTime().getHour())
+                .withMinute(fcfsEventPropertiesForBatch.getStartTime().getMinute())
+                .withSecond(fcfsEventPropertiesForBatch.getStartTime().getSecond());
         return startTime.format(FORMATTER);
     }
 
     public String getEndTime() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime endTime = now.withHour(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[0]))
-                .withMinute(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[1]))
-                .withSecond(Integer.parseInt(fcfsEventPropertiesForBatch.getEndTime().split(":")[2]));
+        LocalDateTime endTime = now
+                .withHour(fcfsEventPropertiesForBatch.getEndTime().getHour())
+                .withMinute(fcfsEventPropertiesForBatch.getEndTime().getMinute())
+                .withSecond(fcfsEventPropertiesForBatch.getEndTime().getSecond());
         return endTime.format(FORMATTER);
     }
 }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/config/LoadSubmissionHistoryJobConfiguration.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/config/LoadSubmissionHistoryJobConfiguration.java
@@ -23,7 +23,8 @@ public class LoadSubmissionHistoryJobConfiguration {
         return new JobBuilder("updateSubmissionHistoryJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .listener(jobTimeLoggingListener)
-                .start(loadSubmissionHistoryStepConfiguration.processCurrentSubmissionHistoryStep(jobRepository, transactionManager))
+                .start(loadSubmissionHistoryStepConfiguration.clearRedisStep(jobRepository, transactionManager))
+                .next(loadSubmissionHistoryStepConfiguration.processCurrentSubmissionHistoryStep(jobRepository, transactionManager))
                 .next(loadSubmissionHistoryStepConfiguration.deleteCurrentSubmissionHistoryStep(jobRepository, transactionManager))
                 .build();
     }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/config/LoadSubmissionHistoryStepConfiguration.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/config/LoadSubmissionHistoryStepConfiguration.java
@@ -1,6 +1,7 @@
 package com.ureca.idle.batch.submissionhistory.config;
 
 import com.ureca.idle.batch.submissionhistory.reader.CurrentSubmissionHistoryItemReader;
+import com.ureca.idle.batch.submissionhistory.tasklet.ClearRedisTasklet;
 import com.ureca.idle.batch.submissionhistory.tasklet.DeleteCurrentSubmissionHistoryTasklet;
 import com.ureca.idle.batch.submissionhistory.writer.TransferSubmissionHistoryWriter;
 import com.ureca.idle.jpa.submission.CurrentRoundSubmission;
@@ -18,6 +19,7 @@ public class LoadSubmissionHistoryStepConfiguration {
     private final CurrentSubmissionHistoryItemReader currentSubmissionHistoryItemReader;
     private final TransferSubmissionHistoryWriter transferSubmissionHistoryWriter;
     private final DeleteCurrentSubmissionHistoryTasklet deleteCurrentSubmissionHistoryTasklet;
+    private final ClearRedisTasklet clearRedisTasklet;
 
     public Step processCurrentSubmissionHistoryStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("saveSubmissionHistoryStep", jobRepository)
@@ -33,4 +35,11 @@ public class LoadSubmissionHistoryStepConfiguration {
                 .tasklet(deleteCurrentSubmissionHistoryTasklet, transactionManager)
                 .build();
     }
+
+    public Step clearRedisStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("clearRedisStep", jobRepository)
+                .tasklet(clearRedisTasklet, transactionManager)
+                .build();
+    }
+
 }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
@@ -1,11 +1,14 @@
 package com.ureca.idle.batch.submissionhistory.reader;
 
+import com.ureca.idle.batch.submissionhistory.TimeUtils;
 import com.ureca.idle.jpa.submission.CurrentRoundSubmission;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
@@ -14,10 +17,17 @@ public class CurrentSubmissionHistoryItemReader {
     private final EntityManagerFactory entityManagerFactory;
 
     public JpaPagingItemReader<CurrentRoundSubmission> currentSubmissionHistoryItemReader() {
+        String startTimeStr = TimeUtils.getStartTime();
+        String endTimeStr = TimeUtils.getEndTime();
+
+        String queryString = "SELECT crs FROM CurrentRoundSubmission crs " +
+                "WHERE crs.timeStamp >= :startTime AND crs.timeStamp <= :endTime";
+
         return new JpaPagingItemReaderBuilder<CurrentRoundSubmission>()
                 .name("currentSubmissionHistoryItemReader")
                 .entityManagerFactory(entityManagerFactory)
-                .queryString("SELECT crs FROM CurrentRoundSubmission crs")
+                .queryString(queryString)
+                .parameterValues(Map.of("startTime", startTimeStr, "endTime", endTimeStr))
                 .pageSize(50)
                 .build();
     }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
@@ -1,6 +1,6 @@
 package com.ureca.idle.batch.submissionhistory.reader;
 
-import com.ureca.idle.batch.submissionhistory.TimeUtils;
+import com.ureca.idle.batch.submissionhistory.SubmissionBatchTimeUtils;
 import com.ureca.idle.jpa.submission.CurrentRoundSubmission;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +15,11 @@ import java.util.Map;
 public class CurrentSubmissionHistoryItemReader {
 
     private final EntityManagerFactory entityManagerFactory;
-    private final TimeUtils timeUtils;
+    private final SubmissionBatchTimeUtils submissionBatchTimeUtils;
 
     public JpaPagingItemReader<CurrentRoundSubmission> currentSubmissionHistoryItemReader() {
-        String startTimeStr = timeUtils.getStartTime();
-        String endTimeStr = timeUtils.getEndTime();
+        String startTimeStr = submissionBatchTimeUtils.getStartTime();
+        String endTimeStr = submissionBatchTimeUtils.getEndTime();
 
         String queryString = "SELECT crs FROM CurrentRoundSubmission crs " +
                 "WHERE crs.timeStamp >= :startTime AND crs.timeStamp <= :endTime";

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/reader/CurrentSubmissionHistoryItemReader.java
@@ -15,10 +15,11 @@ import java.util.Map;
 public class CurrentSubmissionHistoryItemReader {
 
     private final EntityManagerFactory entityManagerFactory;
+    private final TimeUtils timeUtils;
 
     public JpaPagingItemReader<CurrentRoundSubmission> currentSubmissionHistoryItemReader() {
-        String startTimeStr = TimeUtils.getStartTime();
-        String endTimeStr = TimeUtils.getEndTime();
+        String startTimeStr = timeUtils.getStartTime();
+        String endTimeStr = timeUtils.getEndTime();
 
         String queryString = "SELECT crs FROM CurrentRoundSubmission crs " +
                 "WHERE crs.timeStamp >= :startTime AND crs.timeStamp <= :endTime";

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/ClearRedisTasklet.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/ClearRedisTasklet.java
@@ -1,0 +1,26 @@
+package com.ureca.idle.batch.submissionhistory.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClearRedisTasklet implements Tasklet {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        redisTemplate.delete("FCFS");
+
+        log.info("레디스 데이터가 초기화되었습니다.");
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
@@ -16,11 +16,12 @@ import org.springframework.stereotype.Component;
 public class DeleteCurrentSubmissionHistoryTasklet implements Tasklet {
 
     private final JdbcTemplate jdbcTemplate;
+    private final TimeUtils timeUtils;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        String startTimeStr = TimeUtils.getStartTime();
-        String endTimeStr = TimeUtils.getEndTime();
+        String startTimeStr = timeUtils.getStartTime();
+        String endTimeStr = timeUtils.getEndTime();
 
         String deleteQuery = "DELETE FROM current_round_submission WHERE time_stamp >= ? AND time_stamp <= ?";
         int rowsAffected = jdbcTemplate.update(deleteQuery, startTimeStr, endTimeStr);

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
@@ -1,5 +1,6 @@
 package com.ureca.idle.batch.submissionhistory.tasklet;
 
+import com.ureca.idle.batch.submissionhistory.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.StepContribution;
@@ -18,8 +19,13 @@ public class DeleteCurrentSubmissionHistoryTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        jdbcTemplate.execute("TRUNCATE TABLE current_round_submission");
-        log.info("현재 차수 응모 데이터가 전부 삭제되었습니다.");
+        String startTimeStr = TimeUtils.getStartTime();
+        String endTimeStr = TimeUtils.getEndTime();
+
+        String deleteQuery = "DELETE FROM current_round_submission WHERE time_stamp >= ? AND time_stamp <= ?";
+        int rowsAffected = jdbcTemplate.update(deleteQuery, startTimeStr, endTimeStr);
+
+        log.info("{}개의 현재 차수 응모 데이터가 삭제되었습니다.", rowsAffected);
         return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/tasklet/DeleteCurrentSubmissionHistoryTasklet.java
@@ -1,6 +1,6 @@
 package com.ureca.idle.batch.submissionhistory.tasklet;
 
-import com.ureca.idle.batch.submissionhistory.TimeUtils;
+import com.ureca.idle.batch.submissionhistory.SubmissionBatchTimeUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.StepContribution;
@@ -16,12 +16,12 @@ import org.springframework.stereotype.Component;
 public class DeleteCurrentSubmissionHistoryTasklet implements Tasklet {
 
     private final JdbcTemplate jdbcTemplate;
-    private final TimeUtils timeUtils;
+    private final SubmissionBatchTimeUtils submissionBatchTimeUtils;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        String startTimeStr = timeUtils.getStartTime();
-        String endTimeStr = timeUtils.getEndTime();
+        String startTimeStr = submissionBatchTimeUtils.getStartTime();
+        String endTimeStr = submissionBatchTimeUtils.getEndTime();
 
         String deleteQuery = "DELETE FROM current_round_submission WHERE time_stamp >= ? AND time_stamp <= ?";
         int rowsAffected = jdbcTemplate.update(deleteQuery, startTimeStr, endTimeStr);

--- a/src/main/java/com/ureca/idle/batch/submissionhistory/writer/TransferSubmissionHistoryWriter.java
+++ b/src/main/java/com/ureca/idle/batch/submissionhistory/writer/TransferSubmissionHistoryWriter.java
@@ -25,7 +25,7 @@ public class TransferSubmissionHistoryWriter implements ItemWriter<CurrentRoundS
     public void write(Chunk<? extends CurrentRoundSubmission> chunk) {
 
         String sql = "INSERT INTO previous_round_submission " +
-                "(user_id, name, phone_num) VALUES ";
+                "(user_id, name, phone_num, time_stamp) VALUES ";
         StringBuilder values = new StringBuilder();
 
         List<? extends CurrentRoundSubmission> currentRoundSubmissionList = chunk.getItems();

--- a/src/main/resources/properties/event.yml
+++ b/src/main/resources/properties/event.yml
@@ -2,3 +2,5 @@ event:
   fcfs:
     title: FCFS
     limit: 100
+    startTime: "13:00:00"
+    endTime: "12:59:59"


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- [resolves]: [배치 로직 수정](https://trello.com/c/2GLBEOj3/83-id-83-%EB%B0%B0%EC%B9%98-%EB%A1%9C%EC%A7%81-%EC%88%98%EC%A0%95) #ID-83

> ## 💻 작업 내용
- 응모 테이블에 timestamp 컬럼이 추가됨에 따라 배치 시 저장할 컬럼 추가
- 응모 테이블 배치 시 타임스탬프 컬럼 비교를 통해 전 회차 당첨자 테이블만 배치 하는 로직 추가
- 응모 테이블 배치 시작시 Redis 저장소 비우는 로직 추가
- 이벤트 시작 시간과 종료 시간을 event.yml에서 관리하도록 수정
---
> ## 🙇 특이 사항
- 이벤트 시작 시간과 종료시간이 원래 TimeUtils에 있었는데 여기서는 시작 시간과 종료 시간을 알 필요가 없을 것 같아서 event.yml에 두고 가져와서 사용하는 방식을 선택하였습니다.
---
> ## 👻 리뷰 요구사항 (선택)
- x
---
